### PR TITLE
CI: more versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -54,6 +54,9 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.11'
             toxenv: py311-test-pytest73
+          - os: ubuntu-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytest74
             toxargs: --pre
           - os: macos-latest
             python-version: '3.11'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -62,8 +62,8 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-pytestdev
           - os: ubuntu-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
+            python-version: '3.12-dev'
+            toxenv: py312-test-pytestdev
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,13 +42,28 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.9
             toxenv: py39-test-pytest62
-          - os: macos-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
           - os: ubuntu-latest
             python-version: '3.10'
             toxenv: py310-test-pytest70
+          - os: ubuntu-latest
+            python-version: '3.10'
+            toxenv: py310-test-pytest71
+          - os: windows-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytest72
+          - os: ubuntu-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytest73
             toxargs: --pre
+          - os: macos-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytestdev
+          - os: windows-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytestdev
+          - os: ubuntu-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytestdev
 
     steps:
     - uses: actions/checkout@v3

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -11,9 +11,9 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
-* Neither the name of the Astropy Team nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
+* Neither the names of the Astropy or Scientific Python Teams nor the names of
+  their contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -13,13 +13,14 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+from datetime import datetime
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'pytest-doctestplus'
-copyright = '2011-2023, Astropy Infrastructure Team'
-author = 'Astropy Infrastructure Team'
+copyright = f'2023-{datetime.now().year}, Scientific Python Developers'
+author = 'Scientific Python Developers'
 
 
 # -- General configuration ---------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ isolated_build = true
 
 [testenv]
 changedir = .tmp/{envname}
+setenv =
+    # Until a released numpy version is 3.12 compatible, we install the dev wheel
+    py312: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 description = run tests
 deps =
     pytest46: pytest==4.6.*
@@ -23,7 +26,11 @@ deps =
     pytest71: pytest==7.1.*
     pytest72: pytest==7.2.*
     pytest73: pytest==7.3.*
+    pytest74: pytest==7.4.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
+    # We keep seeing pytest related issues with the latest release and python 3.12, keep using the dev version until it's fixed upstream
+    py312: git+https://github.com/pytest-dev/pytest#egg=pytest
+    py312: numpy>=0.0.dev0
 
 extras =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}-test
+    py{37,38,39,310,311,312}-test
     codestyle
 requires =
     setuptools >= 30.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,9 @@ deps =
     pytest61: pytest==6.1.*
     pytest62: pytest==6.2.*
     pytest70: pytest==7.0.*
+    pytest71: pytest==7.1.*
+    pytest72: pytest==7.2.*
+    pytest73: pytest==7.3.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
 
 extras =


### PR DESCRIPTION
This is to close #202 

I'll let CI run, and then will modify one of the devtests to run with python 3.12, which I expect may cause some failures.

Close #208 