### PR TITLE
CI: use numpy printoptions in testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
 from functools import partial
 import textwrap
+from packaging.version import Version
 
 import pytest
+import numpy as np
+
+
+# Keep this until we require numpy to be >=2.0 or there is a directive in doctestplus
+# to support multiple ways of repr
+if Version(np.__version__) > Version("2.0.0.dev0+151"):
+    np.set_printoptions(legacy="1.25")
 
 
 def _wrap_docstring_in_func(func_name, docstring):


### PR DESCRIPTION
This gets rid of the testing failure. Whether to have a directive to accept multiple repr ways or not is a separate question and if the answer is yes, that should come in a separate enhancement PR.