### PR TITLE
MAINT: Remove python3.7 support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -80,11 +80,3 @@ jobs:
       run: python -m pip install tox
     - name: Run Tox
       run: tox ${{ matrix.toxargs }} -v -e ${{ matrix.toxenv }}
-
-    # - name: Slack Notification
-    #   uses: 8398a7/action-slack@v3
-    #   with:
-    #     status: ${{ job.status }}
-    #   env:
-    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-    #   if: always() # TODO: cron

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,17 +19,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest46
+            python-version: 3.8
+            toxenv: py38-test-pytestoldest
           - os: windows-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest50
+            python-version: 3.8
+            toxenv: py38-test-pytest50
           - os: macos-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest51
+            python-version: 3.8
+            toxenv: py38-test-pytest51
           - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest52
+            python-version: 3.8
+            toxenv: py38-test-pytest52
           - os: windows-latest
             python-version: 3.8
             toxenv: py38-test-pytest53

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.1.0 (unreleased)
 ==================
 
+- Versions of Python <3.8 are no longer supported. [#217]
+
 
 1.0.0 (2023-08-11)
 ==================

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -204,7 +204,7 @@ def pytest_configure(config):
     use_rst = config.getini('doctest_rst') or config.option.doctest_rst
     file_ext = config.option.text_file_format or config.getini('text_file_format') or 'rst'
     if use_rst:
-        config.option.doctestglob.append('*.{}'.format(file_ext))
+        config.option.doctestglob.append(f'*.{file_ext}')
 
     # override default comment characters
     ext_comment_pairs = [pair.split('=') for pair in config.getini('text_file_comment_chars')]
@@ -394,7 +394,7 @@ def pytest_configure(config):
                     skip_next = False
                     lines = entry.strip().splitlines()
                     if any(re.match(
-                            '{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines):
+                            f'{comment_char} doctest-skip-all', x.strip()) for x in lines):
                         skip_all = True
                         continue
 
@@ -405,7 +405,7 @@ def pytest_configure(config):
                     # special environment to be in between, e.g. \begin{python}
                     last_lines = lines[-2:]
                     matches = [re.match(
-                        r'{}\s+doctest-skip\s*::(\s+.*)?'.format(comment_char),
+                        fr'{comment_char}\s+doctest-skip\s*::(\s+.*)?',
                         last_line) for last_line in last_lines]
 
                     if len(matches) > 1:
@@ -423,7 +423,7 @@ def pytest_configure(config):
 
                     if config.getoption('remote_data', 'none') != 'any':
                         matches = (re.match(
-                            r'{}\s+doctest-remote-data\s*::'.format(comment_char),
+                            fr'{comment_char}\s+doctest-remote-data\s*::',
                             last_line) for last_line in last_lines)
 
                         if any(matches):
@@ -431,7 +431,7 @@ def pytest_configure(config):
                             continue
 
                     matches = [re.match(
-                        r'{}\s+doctest-requires\s*::\s+(.*)'.format(comment_char),
+                        fr'{comment_char}\s+doctest-requires\s*::\s+(.*)',
                         last_line) for last_line in last_lines]
 
                     if len(matches) > 1:
@@ -487,7 +487,7 @@ def pytest_configure(config):
     config.pluginmanager.unregister(doctest_plugin)
 
 
-class DoctestPlus(object):
+class DoctestPlus:
     def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls, file_globs):
         """
         doctest_module_item_cls should be a class inheriting

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -29,7 +28,7 @@ keywords = doctest, rst, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311,312}-test
+    py{38,39,310,311,312}-test
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -14,7 +14,7 @@ setenv =
     py312: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 description = run tests
 deps =
-    pytest46: pytest==4.6.*
+    pytestoldest: pytest==4.6.0
     pytest50: pytest==5.0.*
     pytest51: pytest==5.1.*
     pytest52: pytest==5.2.*


### PR DESCRIPTION
No code changes, except a few very trivial touch-ups. However, there isn't much point develop future enhancements with python 3.7 in mind. 