### PR TITLE
TST: Use Python 3.12 stable, bump checkout version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: actions/setup-python@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -65,11 +65,11 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-pytestdev
           - os: ubuntu-latest
-            python-version: '3.12-dev'
+            python-version: '3.12'
             toxenv: py312-test-pytestdev
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.12 is released and checkout is now at v4.