### PR TITLE
BUG: Fix module level import requires

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.1.0 (unreleased)
 ==================
 
+- Fix module level ``__doctest_requires__``. [#228]
+
 - Versions of Python <3.8 are no longer supported. [#217]
 
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -673,6 +673,7 @@ class DocTestFinderPlus(doctest.DocTestFinder):
             if mod in cls._import_cache:
                 if not cls._import_cache[mod]:
                     return False
+                continue
 
             if cls._module_checker.check(mod):
                 cls._import_cache[mod] = True
@@ -712,12 +713,16 @@ class DocTestFinderPlus(doctest.DocTestFinder):
 
                 reqs = getattr(obj, '__doctest_requires__', {})
                 for pats, mods in reqs.items():
-                    if not isinstance(pats, tuple):
-                        pats = (pats,)
+                    if self.check_required_modules(mods):
+                        # All mods available, no need to probe
+                        continue
+
                     for pat in pats:
-                        if not fnmatch.fnmatch(test.name, '.'.join((name, pat))):
-                            continue
-                        if not self.check_required_modules(mods):
+                        if pat == '*':
+                            return False
+                        elif pat == '.' and test.name == name:
+                            return False
+                        elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
                             return False
                 return True
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -713,16 +713,20 @@ class DocTestFinderPlus(doctest.DocTestFinder):
 
                 reqs = getattr(obj, '__doctest_requires__', {})
                 for pats, mods in reqs.items():
-                    if self.check_required_modules(mods):
-                        # All mods available, no need to probe
-                        continue
+                    if not isinstance(pats, tuple):
+                        pats = (pats,)
 
                     for pat in pats:
                         if pat == '*':
-                            return False
+                            pass
                         elif pat == '.' and test.name == name:
-                            return False
+                            pass
                         elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
+                            pass
+                        else:
+                            continue  # The pattern does not apply
+
+                        if not self.check_required_modules(mods):
                             return False
                 return True
 

--- a/tests/python/doctests.py
+++ b/tests/python/doctests.py
@@ -1,5 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+"""
+Also module level skips should be matched with `*` and `.`, test at least
+the `.` version (the star would match all others too).
+
+>>> import foobar
+"""
+
 __doctest_skip__ = [
     'skip_this_test',
     'ClassWithSomeBadDocTests.this_test_fails',
@@ -7,6 +14,7 @@ __doctest_skip__ = [
 ]
 
 __doctest_requires__ = {
+    '.': ['foobar'],
     'depends_on_foobar': ['foobar'],
     'depends_on_foobar_submodule': ['foobar.baz'],
     'depends_on_two_modules': ['os', 'foobar'],


### PR DESCRIPTION
Since the logic was written in a negate way compared to the normal skipping, the module level skip didn't take into account the special "*" and "." patterns.

gh-109 probably misdiagnosed the module actually missing only on the run the had pytest-xdist: the test does not seem to ever pass either way.

Closes gh-109