### PR TITLE
MNT: pytest 8.1.1 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Compatibility with pytest 8.2. [#241]
+- Compatibility with pytest 8.1.1 [#242]
 
 1.2.0 (2024-03-04)
 ==================

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -32,6 +32,7 @@ PYTEST_GT_5 = _pytest_version > Version('5.9.9')
 PYTEST_GE_5_4 = _pytest_version >= Version('5.4')
 PYTEST_GE_7_0 = _pytest_version >= Version('7.0')
 PYTEST_GE_8_0 = _pytest_version >= Version('8.0')
+PYTEST_GE_8_1_1 = _pytest_version >= Version('8.1.1')
 PYTEST_GE_8_2 = any([_pytest_version.is_devrelease,
                      _pytest_version.is_prerelease,
                      _pytest_version >= Version('8.2')])
@@ -265,7 +266,7 @@ def pytest_configure(config):
                     from _pytest.pathlib import import_path
                     mode = self.config.getoption("importmode")
 
-                if PYTEST_GE_8_2:
+                if PYTEST_GE_8_1_1:
                     consider_namespace_packages = self.config.getini("consider_namespace_packages")
                     module = import_path(fspath, mode=mode, root=self.config.rootpath,
                                          consider_namespace_packages=consider_namespace_packages)


### PR DESCRIPTION
8.1.1 contains the `consider_namespace_packages` that were addressed in https://github.com/scientific-python/pytest-doctestplus/pull/241 However the fix assumed those changes would be in 8.2 instead of 8.1.1.

This PR adjusts the version check to include the fix for 8.1.1

Fixes #243