### PR TITLE
ci: improving readability of testing matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,7 +38,7 @@ jobs:
           - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "6.0" }
           - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "6.1" }
           # some special cases
-          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "oldest" }
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "4.6" }
           - { os: "ubuntu-20.04", python-version: "3.12", pytest-version: "dev-numpydev" }
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,63 +18,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytestoldest
-          - os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest50
-          - os: macos-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest51
-          - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest52
-          - os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest53
-          - os: ubuntu-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest60
-          - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest61
-          - os: ubuntu-latest
-            python-version: 3.9
-            toxenv: py39-test-pytest62
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest70
-          - os: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310-test-pytest71
-          - os: windows-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytest72
-          - os: ubuntu-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytest73
-          - os: ubuntu-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytest74
-          - os: ubuntu-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytest80
-          - os: macos-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytest80
-          - os: windows-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytest80
-          - os: macos-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
-          - os: windows-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
-          - os: ubuntu-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytestdev-numpydev
+          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytestoldest }
+          - { os: windows-latest, python-version: 3.8, toxenv: py38-test-pytest50 }
+          - { os: macos-latest, python-version: 3.8, toxenv: py38-test-pytest51 }
+          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytest52 }
+          - { os: windows-latest, python-version: 3.8, toxenv: py38-test-pytest53 }
+          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytest60 }
+          - { os: ubuntu-latest, python-version: 3.9, toxenv: py39-test-pytest61 }
+          - { os: ubuntu-latest, python-version: 3.9, toxenv: py39-test-pytest62 }
+          - { os: ubuntu-latest, python-version: 3.10, toxenv: py310-test-pytest70 }
+          - { os: ubuntu-latest, python-version: 3.10, toxenv: py310-test-pytest71 }
+          - { os: windows-latest, python-version: 3.11, toxenv: py311-test-pytest72 }
+          - { os: ubuntu-latest, python-version: 3.11, toxenv: py311-test-pytest73 }
+          - { os: ubuntu-latest, python-version: 3.11, toxenv: py311-test-pytest74 }
+          - { os: ubuntu-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
+          - { os: macos-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
+          - { os: windows-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
+          - { os: macos-latest, python-version: 3.11, toxenv: py311-test-pytestdev }
+          - { os: windows-latest, python-version: 3.11, toxenv: py311-test-pytestdev }
+          - { os: ubuntu-latest, python-version: 3.12, toxenv: py312-test-pytestdev-numpydev }
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,26 +17,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        pytest-version:
+          - "5.3"  # last version of 5.x series
+          - "6.2"  # last version of 6.x series
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "dev"
         include:
-          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytestoldest }
-          - { os: windows-latest, python-version: 3.8, toxenv: py38-test-pytest50 }
-          - { os: macos-latest, python-version: 3.8, toxenv: py38-test-pytest51 }
-          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytest52 }
-          - { os: windows-latest, python-version: 3.8, toxenv: py38-test-pytest53 }
-          - { os: ubuntu-latest, python-version: 3.8, toxenv: py38-test-pytest60 }
-          - { os: ubuntu-latest, python-version: 3.9, toxenv: py39-test-pytest61 }
-          - { os: ubuntu-latest, python-version: 3.9, toxenv: py39-test-pytest62 }
-          - { os: ubuntu-latest, python-version: 3.10, toxenv: py310-test-pytest70 }
-          - { os: ubuntu-latest, python-version: 3.10, toxenv: py310-test-pytest71 }
-          - { os: windows-latest, python-version: 3.11, toxenv: py311-test-pytest72 }
-          - { os: ubuntu-latest, python-version: 3.11, toxenv: py311-test-pytest73 }
-          - { os: ubuntu-latest, python-version: 3.11, toxenv: py311-test-pytest74 }
-          - { os: ubuntu-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
-          - { os: macos-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
-          - { os: windows-latest, python-version: 3.12, toxenv: py312-test-pytest80 }
-          - { os: macos-latest, python-version: 3.11, toxenv: py311-test-pytestdev }
-          - { os: windows-latest, python-version: 3.11, toxenv: py311-test-pytestdev }
-          - { os: ubuntu-latest, python-version: 3.12, toxenv: py312-test-pytestdev-numpydev }
+          # testing some relatively olv versions with Linux only
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "5.0" }
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "5.1" }
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "5.2" }
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "6.0" }
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "6.1" }
+          # some special cases
+          - { os: "ubuntu-20.04", python-version: "3.8", pytest-version: "oldest" }
+          - { os: "ubuntu-20.04", python-version: "3.12", pytest-version: "dev-numpydev" }
 
     steps:
     - uses: actions/checkout@v4
@@ -49,4 +52,12 @@ jobs:
     - name: Install Tox
       run: python -m pip install tox
     - name: Run Tox
-      run: tox ${{ matrix.toxargs }} -v -e ${{ matrix.toxenv }}
+      env:
+        PY: ${{ matrix.python-version }}
+        PT: ${{ matrix.pytest-version }}
+      run: |
+        # crete the token as "pyXY-test-pytestXY" from the matrix with drop dots
+        toxenv=py"${PY//./}"-test-pytest${PT//./}
+        echo $toxenv
+        # run the particular tox environment
+        tox ${{ matrix.toxargs }} -v -e ${toxenv}

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     numpydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 description = run tests
 deps =
-    pytestoldest: pytest==4.6.0
+    pytest46: pytest==4.6.*
     pytest50: pytest==5.0.*
     pytest51: pytest==5.1.*
     pytest52: pytest==5.2.*
@@ -27,6 +27,7 @@ deps =
     pytest73: pytest==7.3.*
     pytest74: pytest==7.4.*
     pytest80: pytest==8.0.*
+    pytest81: pytest==8.1.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
     numpydev: numpy>=0.0.dev0
 


### PR DESCRIPTION
As it is decalted now it is not trivial to make contributor head what are the tested cases...
So first sing a dictionary written in a single line to its closed-to-table reading which is easier for humans; then rather define rules for run with exceptions then special cases...

This also will increase the number of running suits, but I believe it is in favor of extension stability

cc: @bsipocz @pllim