### PR TITLE
CI: use available osx image for old python

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - os: windows-latest
             python-version: '3.8'
             toxenv: py38-test-pytest50
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.8'
             toxenv: py38-test-pytest51
           - os: ubuntu-latest


### PR DESCRIPTION
`macos-latest` is now arm with no available python 3.8, so we use an explicit name for an older os version. This should fix the currently failing CI