### PR TITLE
BUG: Fix multiline code in generate/update diff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.3.0 (unreleased)
 ==================
 
+- Fixing output update for multiline code. [#253]
 
 1.2.1 (2024-03-09)
 ==================

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -896,7 +896,9 @@ def write_modified_file(fname, new_fname, changes):
         if change["test_lineno"] is None:
             bad_tests.append(change["name"])
             continue
-        lineno = change["test_lineno"] + change["example_lineno"] + 1
+        # Find the first line of the output:
+        lineno = change["test_lineno"] + change["example_lineno"]
+        lineno += change["source"].count("\n")
 
         indentation = " " * change["nindent"]
         want = indent(change["want"], indentation, lambda x: True)


### PR DESCRIPTION
The code may have more than one line, so need to account for that.

Closes gh-252