### PR TITLE
MAINT: Remove accidental debug print from new tests

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1459,9 +1459,6 @@ def test_generate_diff_multiline(testdir, capsys):
     +    3
     """)
     captured = capsys.readouterr()
-    print(captured.out)
-    print("====")
-    print(diff)
     assert diff in captured.out
 
     testdir.inline_run(p, "--doctest-plus-generate-diff=overwrite")


### PR DESCRIPTION
I forgot to delete these lines (the pytest print removes the interesting stuff, so it's hard to see what differs just from them).