### PR TITLE
DEP: refactored out runtime dependency on setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Fixing output update for multiline code. [#253]
+- Dropped ``setuptools`` as a runtime dependency. [#258]
 
 1.2.1 (2024-03-09)
 ==================

--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -1,7 +1,7 @@
 import importlib.util
 
-import pkg_resources
-
+from importlib.metadata import distribution
+from packaging.requirements import Requirement
 
 class ModuleChecker:
 
@@ -15,9 +15,15 @@ class ModuleChecker:
     def find_distribution(self, dist):
         """Search for distribution with specified version (eg 'numpy>=1.15')."""
         try:
-            return pkg_resources.require(dist)
+            reqs = Requirement(dist)
+            dist_meta = distribution(reqs.name)
         except Exception:
             return None
+        else:
+            if reqs.specifier.contains(dist_meta.version, prereleases=True):
+                return dist_meta
+            else:
+                return None
 
     def check(self, module):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,13 +33,13 @@ setup_requires =
     setuptools_scm
 install_requires =
     pytest>=4.6
-    setuptools>=30.3.0
     packaging>=17.0
 
 [options.extras_require]
 test =
     numpy
     pytest-remotedata>=0.3.2
+    setuptools>=30.3.0
     sphinx
 
 [options.entry_points]


### PR DESCRIPTION
Yesterday we ran into some issues with the latest version of setuptools at astropy (see [this issue](https://github.com/astropy/astropy/issues/16745) for context).
In summary, what happened is that setuptools 71 brought in a couple runtime side effects, resulting in some confusing error messages.
My analysis showed that `setuptools` is only present in the runtime environment that astropy runs tests with because it's brought in by this package, which only requires it for a single line of code, so I refactored it using standard lib `importlib.metadata` + `packagaging` (which is already a runtime dependency here), eliminating `setuptools` as a runtime dependency, which down the road eliminates a source of instabilitly for any package that relies on pytest-doctestplus.

In case it's not clear (it wasn't to me), note that `pkg_resources` is really part of `setuptools` and not included in the standard library.
