### PR TITLE
MAINT: adding python3.13 to CI and fix any incompatibilities

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -68,20 +68,20 @@ jobs:
             python-version: '3.12'
             toxenv: py312-test-pytest82
           - os: macos-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytest82
+            python-version: '3.13-dev'
+            toxenv: py312-test-pytest83
           - os: windows-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytest82
+            python-version: '3.13-dev'
+            toxenv: py312-test-pytestdev
           - os: macos-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
-          - os: windows-latest
             python-version: '3.11'
             toxenv: py311-test-pytestdev
           - os: ubuntu-latest
             python-version: '3.12'
             toxenv: py312-test-pytestdev-numpydev
+          - os: ubuntu-latest
+            python-version: '3.13-dev'
+            toxenv: py313-test-pytestdev
 
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Fixing output update for multiline code. [#253]
+- Fixing Python 3.13 compatibility. [#260]
 - Dropped ``setuptools`` as a runtime dependency. [#258]
 
 1.2.1 (2024-03-09)

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -900,7 +900,8 @@ def write_modified_file(fname, new_fname, changes):
         lineno = change["test_lineno"] + change["example_lineno"]
         lineno += change["source"].count("\n")
 
-        indentation = " " * change["nindent"]
+        indentation = len(text[lineno-1]) - len(text[lineno-1].lstrip())
+        indentation = text[lineno-1][:indentation]
         want = indent(change["want"], indentation, lambda x: True)
         # Replace fully blank lines with the required `<BLANKLINE>`
         # (May need to do this also if line contains only whitespace)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-test
+    py{38,39,310,311,312,313}-test
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -29,6 +29,7 @@ deps =
     pytest80: pytest==8.0.*
     pytest81: pytest==8.1.*
     pytest82: pytest==8.2.*
+    pytest83: pytest==8.3.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
     numpydev: numpy>=0.0.dev0
 


### PR DESCRIPTION
I see test failures locally, but there is also a puzzling one for older pythons that I see in my dev environment, but not when I run the tests from tox, so ultimately we may run into some new cross incompatibility with some other plugin.

(This will need a changelog once some actual code changes are needed for incompatibility fixes, but not until all the diff stays within the territory of the tests)