### PR TITLE
MAINT: dropping python3.8 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install python-build and twine
       run: python -m pip install build "twine>=3.3"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     - name: Install python-build and twine
       run: python -m pip install build "twine>=3.3"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,26 +20,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: '3.8'
-            toxenv: py38-test-pytestoldest
+            python-version: '3.9'
+            toxenv: py39-test-pytestoldest
           - os: windows-latest
-            python-version: '3.8'
-            toxenv: py38-test-pytest50
+            python-version: '3.9'
+            toxenv: py39-test-pytest50
           - os: macos-13
-            python-version: '3.8'
-            toxenv: py38-test-pytest51
-          - os: ubuntu-latest
-            python-version: '3.8'
-            toxenv: py38-test-pytest52
-          - os: windows-latest
-            python-version: '3.8'
-            toxenv: py38-test-pytest53
-          - os: ubuntu-latest
-            python-version: '3.8'
-            toxenv: py38-test-pytest60
+            python-version: '3.9'
+            toxenv: py39-test-pytest51
           - os: ubuntu-latest
             python-version: '3.9'
-            toxenv: py39-test-pytest61
+            toxenv: py39-test-pytest60
           - os: ubuntu-latest
             python-version: '3.9'
             toxenv: py39-test-pytest62
@@ -74,14 +65,11 @@ jobs:
             python-version: '3.13'
             toxenv: py313-test-pytestdev
           - os: macos-latest
-            python-version: '3.11'
-            toxenv: py311-test-pytestdev
-          - os: ubuntu-latest
             python-version: '3.12'
-            toxenv: py312-test-pytestdev-numpydev
+            toxenv: py312-test-pytestdev
           - os: ubuntu-latest
             python-version: '3.13'
-            toxenv: py313-test-pytestdev
+            toxenv: py313-test-pytestdev-numpydev
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.4.0 (unreleased)
 ==================
 
+- Versions of Python <3.9 are no longer supported. [#274]
 
 1.3.0 (2024-11-25)
 ==================

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -67,13 +67,13 @@ class OutputChecker(doctest.OutputChecker):
         front_sep = r'\s|[*+-,<=(\[]'
         back_sep = front_sep + r'|[>j)\]}]'
 
-        fbeg = r'^{}(?={}|$)'.format(got_floats, back_sep)
-        fmidend = r'(?<={}){}(?={}|$)'.format(front_sep, got_floats, back_sep)
-        self.num_got_rgx = re.compile(r'({}|{})'.format(fbeg, fmidend))
+        fbeg = fr'^{got_floats}(?={back_sep}|$)'
+        fmidend = fr'(?<={front_sep}){got_floats}(?={back_sep}|$)'
+        self.num_got_rgx = re.compile(fr'({fbeg}|{fmidend})')
 
-        fbeg = r'^{}(?={}|$)'.format(want_floats, back_sep)
-        fmidend = r'(?<={}){}(?={}|$)'.format(front_sep, want_floats, back_sep)
-        self.num_want_rgx = re.compile(r'({}|{})'.format(fbeg, fmidend))
+        fbeg = fr'^{want_floats}(?={back_sep}|$)'
+        fmidend = fr'(?<={front_sep}){want_floats}(?={back_sep}|$)'
+        self.num_want_rgx = re.compile(fr'({fbeg}|{fmidend})')
 
         # As of 2023-09-26, Python base class has no init, but just in case
         # it acquires one.
@@ -220,7 +220,7 @@ class OutputChecker(doctest.OutputChecker):
         # blank line, unless the DONT_ACCEPT_BLANKLINE flag is used.
         if not (flags & doctest.DONT_ACCEPT_BLANKLINE):
             # Replace <BLANKLINE> in want with a blank line.
-            want = re.sub(r'(?m)^{}\s*?$'.format(re.escape(doctest.BLANKLINE_MARKER)),
+            want = re.sub(fr'(?m)^{re.escape(doctest.BLANKLINE_MARKER)}\s*?$',
                           '', want)
             # If a line in got contains only spaces, then remove the
             # spaces.

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -893,7 +893,7 @@ def write_modified_file(fname, new_fname, changes):
     changes.sort(key=lambda x: (x["test_lineno"], x["example_lineno"]),
                  reverse=True)
 
-    with open(fname, "r") as f:
+    with open(fname) as f:
         text = f.readlines()
 
     for change in changes:
@@ -923,7 +923,7 @@ def write_modified_file(fname, new_fname, changes):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     changesets = DebugRunnerPlus._changesets
     diff_mode = DebugRunnerPlus._generate_diff
-    DebugRunnerPlus._changesets = defaultdict(lambda: [])
+    DebugRunnerPlus._changesets = defaultdict(list)
     DebugRunnerPlus._generate_diff = None
     all_bad_tests = []
     if not diff_mode:
@@ -1004,7 +1004,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 
 class DebugRunnerPlus(doctest.DebugRunner):
-    _changesets = defaultdict(lambda: [])
+    _changesets = defaultdict(list)
     _generate_diff = False
 
     def __init__(self, checker=None, verbose=None, optionflags=0,

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -29,7 +28,7 @@ keywords = doctest, rst, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tests/python/doctests.py
+++ b/tests/python/doctests.py
@@ -80,7 +80,7 @@ def depends_on_two_modules():
     """
 
 
-class ClassWithSomeBadDocTests(object):
+class ClassWithSomeBadDocTests:
     def this_test_works():
         """
         This test should be executed by --doctest-plus and should pass.
@@ -98,7 +98,7 @@ class ClassWithSomeBadDocTests(object):
         """
 
 
-class ClassWithAllBadDocTests(object):
+class ClassWithAllBadDocTests:
     def this_test_fails(self):
         """
         This test will cause a failure if __doctest_skip__ is not working.

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1142,7 +1142,7 @@ def test_main(testdir):
 
 
 @pytest.mark.xfail(
-        python_version() in ('3.11.9', '3.11.10', '3.12.3'),
+        python_version() in ('3.11.9', '3.11.10', '3.11.11', '3.12.3'),
         reason='broken by https://github.com/python/cpython/pull/115440')
 def test_ufunc(testdir):
     pytest.importorskip('numpy')

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -314,7 +314,7 @@ class TestFloats:
         c = OutputChecker()
         got = []
         for char in ['A', 'B', 'C', 'D', 'E']:
-            got.append('{} {}'.format(char, float(ord(char))))
+            got.append(f'{char} {float(ord(char))}')
         got = '\n'.join(got)
 
         want = "A 65.0\nB 66.0\n...G 70.0"

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -314,7 +314,7 @@ class TestFloats:
         c = OutputChecker()
         got = []
         for char in ['A', 'B', 'C', 'D', 'E']:
-            got.append('%s %s' % (char, float(ord(char))))
+            got.append('{} {}'.format(char, float(ord(char))))
         got = '\n'.join(got)
 
         want = "A 65.0\nB 66.0\n...G 70.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313}-test
+    py{39,310,311,312,313}-test
     codestyle
 requires =
     setuptools >= 30.3.0


### PR DESCRIPTION
I have some issues locally when running the tests, please don't merge this just yet even if CI is all green, so I can ensure that it's indeed just a local issue (I don't see it with tox, but do see it when running tests directly in the source)