### PR TITLE
Make compatible with pytest-asyncio

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -70,6 +70,9 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.13'
             toxenv: py313-test-pytestdev-numpydev
+          - os: ubuntu-latest
+            python-version: '3.13'
+            toxenv: py313-test-pytest83-pytestasyncio
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.4.0 (unreleased)
 ==================
 
+- Fixing compatibility with pytest-asyncio. [#278]
+
 - Versions of Python <3.9 are no longer supported. [#274]
 
 1.3.0 (2024-11-25)

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -342,6 +342,7 @@ def pytest_configure(config):
                             test.name, self, runner, test)
 
     class DocTestTextfilePlus(pytest.Module):
+        obj = None
 
         def collect(self):
             if PYTEST_GE_7_0:

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -11,6 +11,13 @@ import pytest
 import doctest
 from pytest_doctestplus.output_checker import OutputChecker, FLOAT_CMP
 
+try:
+    import pytest_asyncio  # noqa: F401
+    has_pytest_asyncio = True
+except ImportError:
+    has_pytest_asyncio = False
+
+
 
 pytest_plugins = ['pytester']
 
@@ -1123,6 +1130,9 @@ def test_fail_data_dependency(testdir, cont_on_fail):
     assert ("something()\nUNEXPECTED EXCEPTION: NameError" in report.longreprtext) is cont_on_fail
 
 
+@pytest.mark.xfail(
+        has_pytest_asyncio,
+        reason='pytest_asyncio monkey-patches .collect()')
 def test_main(testdir):
     pkg = testdir.mkdir('pkg')
     code = dedent(

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     pytest83: pytest==8.3.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
     numpydev: numpy>=0.0.dev0
+    pytestasyncio: pytest-asyncio
 
 extras =
     test


### PR DESCRIPTION
`pytest-asyncio` reads [1] `collector.obj` during test collection which raises an `ImportError` for `DocTestTextfilePlus`. We fix this by aligning that class with pytest’s `DoctestTextfile` [2] and setting `obj` to `None`.

Fixes #256

[1]: https://github.com/pytest-dev/pytest-asyncio/blob/eb63d5ad0ca21041726ada3d5c00211d36418a9b/pytest_asyncio/plugin.py#L640
[2]: https://github.com/pytest-dev/pytest/blob/fc56ae365fcdea800f91683186136a8191e22399/src/_pytest/doctest.py#L421