### PR TITLE
TST: adding new python version to the fail list

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1210,7 +1210,7 @@ def test_main(testdir):
 
 
 @pytest.mark.xfail(
-        python_version() in ('3.11.9', '3.11.10', '3.11.11', '3.12.3'),
+        python_version() in ('3.11.9', '3.11.10', '3.11.11', '3.11.12', '3.12.3'),
         reason='broken by https://github.com/python/cpython/pull/115440')
 def test_ufunc(testdir):
     pytest.importorskip('numpy')


### PR DESCRIPTION
This should fix the failing jobs we currently see in cron