### PR TITLE
CI: adding deprecation filterwarning for pytest-asyncio

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,9 @@ filterwarnings =
     error
     ignore:file format.*:UserWarning
     ignore:.*non-empty pattern match.*:FutureWarning
+    # For pytest-asyncio deprecations that is expected to be resolved upstream
+    # https://github.com/pytest-dev/pytest-asyncio/issues/924
+    ignore:The configuration option "asyncio_default_fixture_loop_scope":pytest.PytestDeprecationWarning
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Follow-up for https://github.com/scientific-python/pytest-doctestplus/pull/293#issuecomment-2913788849, this filter should take care of all 63 test failures.

