### PR TITLE
TST: new python version out, new xfail for the test

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1212,7 +1212,7 @@ def test_main(testdir):
 
 
 @pytest.mark.xfail(
-        python_version() in ('3.11.9', '3.11.10', '3.11.11', '3.11.12', '3.12.3'),
+        python_version() in ('3.11.9', '3.11.10', '3.11.11', '3.11.12', '3.11.13', '3.12.3'),
         reason='broken by https://github.com/python/cpython/pull/115440')
 def test_ufunc(testdir):
     pytest.importorskip('numpy')


### PR DESCRIPTION
This should fix the 3.11 failures. 

I can't recall seeing the windows one before, if it keeps failing in this PR, maybe @pllim already has an idea about it.